### PR TITLE
User-defined config

### DIFF
--- a/tasks/init/project/root/grunt.js
+++ b/tasks/init/project/root/grunt.js
@@ -1,6 +1,11 @@
+var fs = require('fs');
+var extend = require('node.extend');
+var path = require('path');
+
 module.exports = function (grunt) {
 
   // load js paths
+  var cfgPath = "tasks/cfg";
   var jsFiles = require('./app/js/files.js').map(function (file) {
     if (file == "js/config/envs/dev.js") {
       file = "js/config/envs/prod.js";
@@ -10,7 +15,7 @@ module.exports = function (grunt) {
 
   jsFiles.unshift('phonegap/iphone/www/cordova-1.7.0.js');
 
-  grunt.initConfig({
+  var cfg = {
     js: {
       files: jsFiles
     },
@@ -121,7 +126,16 @@ module.exports = function (grunt) {
     release: {
       "app/assets/app.js": '<config:js.files>'
     }
-  });
+  };
+ 
+  // deep-merge user configs
+  if (path.existsSync(cfgPath)) {
+    grunt.utils._.each(fs.readdirSync(cfgPath), function(cfg_file) {
+      extend(true, cfg, JSON.parse(fs.readFileSync(cfgpath + cfg_file))); 
+    });
+  }
+
+  grunt.initConfig(cfg);
 
   // Load local tasks
   grunt.loadTasks("tasks");

--- a/tasks/init/project/root/grunt.js
+++ b/tasks/init/project/root/grunt.js
@@ -131,7 +131,9 @@ module.exports = function (grunt) {
   // deep-merge user configs
   if (path.existsSync(cfgPath)) {
     grunt.utils._.each(fs.readdirSync(cfgPath), function(cfg_file) {
-      extend(true, cfg, JSON.parse(fs.readFileSync(cfgpath + cfg_file))); 
+      if (cfg_file.match(/.*\.json$/)) {
+        extend(true, cfg, JSON.parse(fs.readFileSync(cfgPath + '/' + cfg_file))); 
+      } 
     });
   }
 

--- a/tasks/init/project/root/package.json
+++ b/tasks/init/project/root/package.json
@@ -19,7 +19,8 @@
     "grunt": "0.3.9",
     "grunt-jasmine-task": "latest",
     "html-minifier": "latest",
-    "clean-css": "0.3.2"
+    "clean-css": "0.3.2",
+    "node.extend": "latest"
   },
   "keywords": [],
   "engines": {

--- a/tasks/init/project/root/tasks/cfg/.gitignore
+++ b/tasks/init/project/root/tasks/cfg/.gitignore
@@ -1,0 +1,1 @@
+# Force git to check in this dir


### PR DESCRIPTION
This implements support for user-defined configs which can be used in combination with user-defined tasks.

User-defined configs are placed in `tasks/cfg` and should be `.json` files.

For example, to implement support for `compass` compilation, copy `compass.js` to `tasks` and then create a file under `tasks/cfg` like `compass.json` containing:

```
{
  "compass": {
    "dist": {
      "src": "app/sass/",
      "dest": "app/css/"
    }
  },
  "watch": {
    "compass": {
      "files": ["app/sass/**/*.scss", "app/sass/**/*.sass"],
      "tasks": "compass"
    }
  }
}
```

then you can run:

`grunt compass` or `grunt watch` to watch for sass changes and execute compass
